### PR TITLE
Fix for downloading empty jpg files

### DIFF
--- a/answer.py
+++ b/answer.py
@@ -60,7 +60,7 @@ class SinglePost:
         locator = PostLocator.img
         image = self.post.select_one(locator)
         if image:
-            self.image_link = image.attrs['src']
+            self.image_link = image.attrs['srcset']
             self.image_extension = self.image_link.split('.')[-1]
             return True
         else:

--- a/answer.py
+++ b/answer.py
@@ -5,7 +5,7 @@ from locators import *
 class SinglePost:
     def __init__(self, question):
 
-        #caï¿½e pojedyncze zapytanie w HTML
+        #ca³e pojedyncze zapytanie w HTML
         self.post = question
 
     def __repr__(self):
@@ -60,7 +60,7 @@ class SinglePost:
         locator = PostLocator.img
         image = self.post.select_one(locator)
         if image:
-            self.image_link = image.attrs['srcset']
+            self.image_link = image.attrs['src']
             self.image_extension = self.image_link.split('.')[-1]
             return True
         else:

--- a/answer.py
+++ b/answer.py
@@ -5,7 +5,7 @@ from locators import *
 class SinglePost:
     def __init__(self, question):
 
-        #ca³e pojedyncze zapytanie w HTML
+        #caï¿½e pojedyncze zapytanie w HTML
         self.post = question
 
     def __repr__(self):
@@ -60,7 +60,7 @@ class SinglePost:
         locator = PostLocator.img
         image = self.post.select_one(locator)
         if image:
-            self.image_link = image.attrs['src']
+            self.image_link = image.attrs['srcset']
             self.image_extension = self.image_link.split('.')[-1]
             return True
         else:

--- a/locators.py
+++ b/locators.py
@@ -11,5 +11,5 @@ class PostLocator:
     date = 'div.streamItem_properties div.streamItem_details a time'
     answer = 'div.streamItem_content'
     likes = 'div.streamItem_footer div.heartButton a.counter'
-    img = 'div.streamItem_visual a img'
+    img = 'div.streamItem_visual a picture source'
     asker_url = 'header.streamItem_header a author'

--- a/locators.py
+++ b/locators.py
@@ -11,5 +11,5 @@ class PostLocator:
     date = 'div.streamItem_properties div.streamItem_details a time'
     answer = 'div.streamItem_content'
     likes = 'div.streamItem_footer div.heartButton a.counter'
-    img = 'div.streamItem_visual a picture source'
+    img = 'div.streamItem_visual a img'
     asker_url = 'header.streamItem_header a author'


### PR DESCRIPTION
Some old thumbnails does not exists anymore. That results in downloading an empty jpg file. This pull request solves this issue. And the script now downloads the full res image instead of the thumbnail.